### PR TITLE
Add Heroku's port to http_port config

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -57,7 +57,7 @@ const config = {
             enableDecrement: getBool(process.env.ENABLE_DECREMENT, true),
         },
         http: {
-            http_port: process.env.HTTP_PORT || 3333,
+            http_port: process.env.PORT || process.env.HTTP_PORT || 3333,
             wss_port: process.env.WSS_PORT || 3334,
             web_path: process.env.WEB_PATH ? fixPath(process.env.WEB_PATH) : '/heyburrito/',
             api_path: process.env.API_PATH ? fixPath(process.env.API_PATH) : '/api/',


### PR DESCRIPTION
When Heroku starts, it assigns a random port to be used, and exposes this on process.env.PORT. 

Unfortunately, we can't enforce a particular port, and so cannot define the HTTP_PORT environment value. This means we cannot run HeyBurrito on Heroku.

To fix this, we could change HTTP_PORT to PORT, but this is a breaking change.

Alternatively, we could load the process.env.PORT value if it exists, and if not then load process.env.HTTP_PORT. This too is a breaking change for users that have process.env.PORT defined for some reason without using it, but it's not as likely.

This PR fixes #59 