### PR TITLE
mapping name instead of real_name if bot, and mongodbmem conf removal

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,6 @@
     "docker-build": "docker build -t chralp/heyburrito . && docker tag chralp/heyburrito chralp/heyburrito",
     "docker-push": "docker push chralp/heyburrito"
   },
-  "config": {
-    "mongodbMemoryServer": {
-      "version": "latest"
-    }
-  },
   "license": "MIT",
   "dependencies": {
     "@slack/rtm-api": "^5.0.3",

--- a/src/slack/Wbc.ts
+++ b/src/slack/Wbc.ts
@@ -26,7 +26,7 @@ class Wbc {
             const arr = x.is_bot ? bots : users;
             arr.push({
                 id: x.id,
-                name: x.real_name,
+                name: x.is_bot ? x.name : x.real_name,
                 memberType: x.is_restricted ? 'guest' : 'member',
                 avatar: x.profile.image_48,
             });


### PR DESCRIPTION
#58 

Mapping name from slack instead of real_name if bot. We want real_name for users, on the webinterface.
And removal of mongodbmem config due to some issues.