### PR TITLE
adding fix to trim down env burrito due to issues

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -26,11 +26,11 @@ interface Updates {
 }
 const emojis: Array<Emojis> = [];
 
-const incEmojis = emojiInc.split(',');
+const incEmojis = emojiInc.split(',').map((emoji => emoji.trim()));
 incEmojis.forEach((emoji: string) => emojis.push({ type: 'inc', emoji }));
 
 if (!disableEmojiDec) {
-    const decEmojis = emojiDec.split(',');
+    const decEmojis = emojiDec.split(',').map((emoji => emoji.trim()));
     decEmojis.forEach((emoji: string) => emojis.push({ type: 'dec', emoji }));
 }
 
@@ -47,7 +47,6 @@ const giveBurritos = async (giver: string, updates: Updates[]) => {
 };
 
 const notifyUser = (user: string, message: string) => Wbc.sendDM(user, message);
-
 
 const handleBurritos = async (giver: string, updates: Updates[]) => {
     if (enableDecrement) {

--- a/test/bot-test.ts
+++ b/test/bot-test.ts
@@ -15,7 +15,7 @@ const loadMiddleware = ({ enable_decrement }) => {
                 enableDecrement: enable_decrement,
                 dailyCap: 5,
                 dailyDecCap: 5,
-                emojiInc: ':burrito:',
+                emojiInc: ' :burrito: ',
                 emojiDec: ':rottenburrito:',
                 disableEmojiDec: false,
             }

--- a/test/parseMessage-test.ts
+++ b/test/parseMessage-test.ts
@@ -157,6 +157,27 @@ describe('parseMessage-test', () => {
 
         });
 
+        it('should return 4 INC updates, two users, burrito before user', () => {
+
+            msg = {
+                user: 'USER1',
+                text: ':burrito: :burrito: <@USER2> <@USER3>',
+            }
+
+            resultShouldBe = {
+                giver: 'USER1',
+                updates:
+                    [{ username: 'USER2', type: 'inc' },
+                    { username: 'USER3', type: 'inc' },
+                    { username: 'USER2', type: 'inc' },
+                    { username: 'USER3', type: 'inc' }]
+            }
+            res = parseMessage(msg, emojis)
+            expect(res).to.deep.equal(resultShouldBe)
+
+        });
+
+
         it('should return 2 DEC updates, one user', () => {
             msg = {
                 user: 'USER1',


### PR DESCRIPTION
#56 
Trims down emojis to ensure that emoji does not contains any whitespace.